### PR TITLE
Rm crew experience embeded

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -5,4 +5,5 @@ from .crew_member_serializer import CrewMemberSerializer
 from .employer_serializer import EmployerSerializer
 from .application_serializer import ApplicationSerializer
 from .crew_member_role_serializer import CrewMemberRoleSerializer
+from .crew_member_role_read_serializer import CrewMemberRoleReadSerializer
 from .user_serializer import UserSerializer

--- a/api/serializers/application_serializer.py
+++ b/api/serializers/application_serializer.py
@@ -13,6 +13,10 @@ class ApplicationSerializer(serializers.HyperlinkedModelSerializer):
     """
     class Meta:
         fields = (
-            '__all__'
+            'id',
+            'url',
+            'accepted',
+            'crew_member',
+            'event'
         )
         model = Application

--- a/api/serializers/crew_member_role_read_serializer.py
+++ b/api/serializers/crew_member_role_read_serializer.py
@@ -7,7 +7,7 @@ from api.models import CrewMemberRole
     purpose: to create the serializer class for the intersection table of crew memebrs to roles
 """
 
-class CrewMemberRoleSerializer(serializers.HyperlinkedModelSerializer):
+class CrewMemberRoleReadSerializer(serializers.HyperlinkedModelSerializer):
     """
     Serializer for the crew member role serializer class
     """
@@ -20,4 +20,4 @@ class CrewMemberRoleSerializer(serializers.HyperlinkedModelSerializer):
             'crew_member',
         )
         model = CrewMemberRole
-        # depth = 1
+        depth = 1

--- a/api/serializers/crew_member_role_serializer.py
+++ b/api/serializers/crew_member_role_serializer.py
@@ -13,7 +13,11 @@ class CrewMemberRoleSerializer(serializers.HyperlinkedModelSerializer):
     """
     class Meta:
         fields = (
-            '__all__'
+            'id',
+            'url',
+            'years_experience',
+            'role',
+            'crew_member',
         )
         model = CrewMemberRole
-        depth=1
+        depth = 1

--- a/api/serializers/crew_member_role_serializer.py
+++ b/api/serializers/crew_member_role_serializer.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from api.models import CrewMemberRole
+from .crew_member_role_read_serializer import CrewMemberRoleReadSerializer
 
 """
     module: crew member role serializer
@@ -21,3 +22,7 @@ class CrewMemberRoleSerializer(serializers.HyperlinkedModelSerializer):
         )
         model = CrewMemberRole
         # depth = 1
+
+    def to_representation(self, instance):
+        serializer = CrewMemberRoleReadSerializer(instance, context=self.context)
+        return serializer.data

--- a/api/serializers/crew_member_role_serializer.py
+++ b/api/serializers/crew_member_role_serializer.py
@@ -16,3 +16,4 @@ class CrewMemberRoleSerializer(serializers.HyperlinkedModelSerializer):
             '__all__'
         )
         model = CrewMemberRole
+        depth=1

--- a/api/serializers/crew_member_serializer.py
+++ b/api/serializers/crew_member_serializer.py
@@ -11,6 +11,15 @@ class CrewMemberSerializer(serializers.HyperlinkedModelSerializer):
     user = UserSerializer(many=False, read_only=True)
 
     class Meta:
-        fields = '__all__'
+        fields = (
+            'id',
+            'url',
+            'user',
+            'verified',
+            'city',
+            'state',
+            'will_travel',
+            'roles'
+        )
         model = CrewMember
         depth = 1

--- a/api/views/crew_member_role_view.py
+++ b/api/views/crew_member_role_view.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
 from api.serializers import CrewMemberRoleSerializer
-from api.models import CrewMemberRole
+from api.models import CrewMemberRole, CrewMember
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 """
@@ -16,3 +16,14 @@ class CrewMemberRoleView(viewsets.ModelViewSet):
     queryset = CrewMemberRole.objects.all()
     serializer_class = CrewMemberRoleSerializer
     permission_classes = (IsAuthenticatedOrReadOnly,)
+
+    def get_queryset(self):
+        if self.request.query_params.get('crew_member'):
+            crew_member = CrewMember.objects.get(id=self.request.query_params.get('crew_member', None))
+            queryset = CrewMemberRole.objects.filter(crew_member=crew_member)
+        else:
+            queryset = CrewMemberRole.objects.all()
+
+        return queryset
+        
+

--- a/api/views/crew_member_role_view.py
+++ b/api/views/crew_member_role_view.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-from api.serializers import CrewMemberRoleSerializer
+from api.serializers import CrewMemberRoleSerializer, CrewMemberRoleReadSerializer
 from api.models import CrewMemberRole, CrewMember
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
@@ -27,3 +27,10 @@ class CrewMemberRoleView(viewsets.ModelViewSet):
         return queryset
         
 
+    def get_serializer_class(self):
+        
+        if self.request.method in ['GET']:
+            
+            return CrewMemberRoleReadSerializer
+            
+        return CrewMemberRoleSerializer


### PR DESCRIPTION
## Link to Ticket

Autolink format: hashtag and number, ex: #1094

Closes #

## Description of Proposed Changes
worked on crew member role endpoint to embed information and allow it to be filtered by specific crew members. This will probably require some frontend refactoring but it should work out better in the long run.

## Steps to Test

Outline the steps to test

```sh
git fetch --all
git checkout rm-crew-experience-embeded
```
1. pull down code
1. run django server
1. go to crew member role endpoint
1. you can filter this endpoint by adding a ?crew_member=1 to the end of the url adding any crew member id in place of 1
1. information returned should have embeded information about the roles
1. in the frontend this table should be queried rather than the information embeded in the crew profile endpoint to display crew member experience.

## Impacted Areas in Application
crew member role endpoint

List general components of the application that this PR will affect:

## Mentions @username

Tag users that need to review this code

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[ ] I certify that all existing tests pass

## Deploy Notes

Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Definition of Done

1. The project must be fully documented. This includes the following:
1. Complete README that documents the steps to install the code, how to install any dependencies, or system configuration needed.
1. Every class must be documented with purpose, author, and methods.
1. Every method must be documented with purpose and argument list - which itself must contain a short purpose for each argument.
1. The project must be able to run fully, and without errors, on each teammate's system.
1. Fulfills every requirement.
1. Every line of code has been peer reviewed.
1. For projects that require unit testing, core functionality must be identified and have at least one test for each
