### PR TITLE
created new event read serializer with embeded information

### DIFF
--- a/api/models/event.py
+++ b/api/models/event.py
@@ -22,6 +22,7 @@ class Event(models.Model):
     start_date = models.DateField()
     end_date = models.DateField()
     description = models.CharField(max_length=200)
+    notes = models.CharField(max_length=2000)
     total_pay = models.IntegerField()
     show_count = models.IntegerField()
     required_experience = models.CharField(max_length=500)

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,6 +1,7 @@
 from .genre_serializer import GenreSerializer
 from .role_serializer import RoleSerializer
 from .event_serializer import EventSerializer
+from .event_read_serializer import EventReadSerializer
 from .crew_member_serializer import CrewMemberSerializer
 from .employer_serializer import EmployerSerializer
 from .application_serializer import ApplicationSerializer

--- a/api/serializers/event_read_serializer.py
+++ b/api/serializers/event_read_serializer.py
@@ -2,20 +2,23 @@ from rest_framework import serializers
 from api.models import Event
 from .crew_member_serializer import CrewMemberSerializer
 from .employer_serializer import EmployerSerializer
-from .event_read_serializer import EventReadSerializer
+from .genre_serializer import GenreSerializer
+from .role_serializer import RoleSerializer
 
 """
     module: event serializer
     author: riley mathews
-    purpose: to create the serializer class for the events model to expose it in the api
+    purpose: to create the serializer class for the events model to expose it in the api, this serializer is only used in get operations
 """
 
-class EventSerializer(serializers.HyperlinkedModelSerializer):
+class EventReadSerializer(serializers.HyperlinkedModelSerializer):
     """
     Serializer for the event class
     """
     crew_member = CrewMemberSerializer(many=True, read_only=True)
     employer = EmployerSerializer(many=False, read_only=True)
+    genres = GenreSerializer(many=True, read_only=True)
+    role = RoleSerializer(many=False, read_only=True)
 
     class Meta:
         fields = (
@@ -36,7 +39,3 @@ class EventSerializer(serializers.HyperlinkedModelSerializer):
             'crew_member',
         )
         model = Event
-
-    def to_representation(self, instance):
-        serializer = EventReadSerializer(instance, context=self.context)
-        return serializer.data

--- a/api/views/event_view.py
+++ b/api/views/event_view.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets
-from api.serializers import EventSerializer
+from api.serializers import EventSerializer, EventReadSerializer
 from api.models import Event
 from rest_framework import status
 from rest_framework.response import Response
@@ -30,3 +30,10 @@ class EventView(viewsets.ModelViewSet):
             queryset = Event.objects.all()
 
         return queryset
+
+    def get_serializer_class(self):
+        if self.request.method in ['GET']:
+            
+            return EventReadSerializer
+            
+        return EventSerializer


### PR DESCRIPTION
# LINKED TICKET
this ticket should be tested with the frontend ticket using the same branch name

## Link to Ticket

Autolink format: hashtag and number, ex: #1094

Closes #

## Description of Proposed Changes
Edited event view to use different serializers on post and creation. On post all foreign key information can simply be a url, or with event genres an array of genre urls. On get this url will be replaced with embeded information about that foreign key object.

## Steps to Test

Outline the steps to test

```sh
git fetch --all
git checkout rm-refactor-event-creation
```
1. pull down code
1. this ticket is kind of hard to test purely in the backend. Posting to an event from the backend should work the same as it always has. But when you look at the event information about role and genres should be embedded. 

## Impacted Areas in Application
event endpoint

List general components of the application that this PR will affect:

## Mentions @username

Tag users that need to review this code

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[ ] I certify that all existing tests pass

## Deploy Notes

Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Definition of Done

1. The project must be fully documented. This includes the following:
1. Complete README that documents the steps to install the code, how to install any dependencies, or system configuration needed.
1. Every class must be documented with purpose, author, and methods.
1. Every method must be documented with purpose and argument list - which itself must contain a short purpose for each argument.
1. The project must be able to run fully, and without errors, on each teammate's system.
1. Fulfills every requirement.
1. Every line of code has been peer reviewed.
1. For projects that require unit testing, core functionality must be identified and have at least one test for each
